### PR TITLE
Remove <p> tags around row

### DIFF
--- a/required-foundation-column-shortcode.php
+++ b/required-foundation-column-shortcode.php
@@ -164,6 +164,9 @@ class REQ_Column_Shortcode {
      */
     public function do_shortcode( $attr, $content = null ) {
 
+        /* remove <p> tags around rows */
+        $content = preg_replace('#^<\/p>|<p>$#', '', $content);
+
         /* If there's no content, just return back what we got. */
         if ( is_null( $content ) )
             return $content;


### PR DESCRIPTION
Hi! I found your plugin code yesterday searching for quick way to add column controls to Editor in a Foundation-based theme. This plugin is nearly perfect for my needs.

I prefer not to have `<p>` tags wrapping around the rows—I've added a line to remove the `<p>` tags and thought you might consider baking it in to your master.
